### PR TITLE
New event: OnImageClicked - optional imagePointer 

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ export class AppComponent implements OnInit {
 export interface GALLERY_CONF {
   imageBorderRadius?: string; // css border radius of image (default 3px)
   imageOffset?: string; // add gap between image and it's container (default 20px)
+  imagePointer? :boolean; // show a pointer on image, should be true when handling onImageClick event (default false)
   showDeleteControl?: boolean; // show image delete icon (default false)
   showCloseControl?: boolean; // show gallery close icon (default true)
   showExtUrlControl?: boolean; // show image external url icon (default true)

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ export class AppModule { }
 [conf]="conf"
 (onOpen)="galleryOpened($event)"
 (onClose)="galleryClosed()"
+(onImageClicked)="galleryImageClicked($event)"
 (onImageChange)="galleryImageChanged($event)"
 (onDelete)="deleteImage($event)"
 ></ngx-image-gallery>
@@ -122,6 +123,11 @@ export class AppComponent implements OnInit {
     console.info('Gallery closed.');
   }
 
+  // callback on gallery image clicked
+  galleryImageClicked(index) {
+    console.info('Gallery image clicked with index ', index);
+  }
+  
   // callback on gallery image changed
   galleryImageChanged(index) {
     console.info('Gallery image changed to index ', index);

--- a/module/components/ngx-image-gallery/ngx-image-gallery.component.html
+++ b/module/components/ngx-image-gallery/ngx-image-gallery.component.html
@@ -8,6 +8,7 @@
              [class.active]="!loading && (i == activeImageIndex)"
              [ngStyle]="{top: conf.imageOffset, bottom: conf.imageOffset}">
             <img *ngIf="i == activeImageIndex" [src]="image.url" [alt]="image.altText || ''"
+                 [style.cursor]="conf.imagePointer?  'pointer':'default'"
                  [style.borderRadius]="conf.imageBorderRadius" (click)="onImageClick.next(activeImageIndex)"/>
         </div>
 

--- a/module/components/ngx-image-gallery/ngx-image-gallery.component.html
+++ b/module/components/ngx-image-gallery/ngx-image-gallery.component.html
@@ -1,16 +1,19 @@
 <!-- images and image information container -->
-<div class="galleria" mouseWheel (mouseWheelDown)="mouseWheelDown()" (mouseWheelUp)="mouseWheelUp()" (contextmenu)="rightClickOnImage($event)">
-  <!-- images -->
-  <div class="images-container" (swiperight)="prev()" (swipeleft)="next()">
-    <!-- images array -->
-    <div class="image" *ngFor="let image of images; let i = index;" [class.active]="!loading && (i == activeImageIndex)" 
-    [ngStyle]="{top: conf.imageOffset, bottom: conf.imageOffset}">
-      <img *ngIf="i == activeImageIndex" [src]="image.url" [alt]="image.altText || ''" [style.borderRadius]="conf.imageBorderRadius"/>
-    </div>
+<div class="galleria" mouseWheel (mouseWheelDown)="mouseWheelDown()" (mouseWheelUp)="mouseWheelUp()"
+     (contextmenu)="rightClickOnImage($event)">
+    <!-- images -->
+    <div class="images-container" (swiperight)="prev()" (swipeleft)="next()">
+        <!-- images array -->
+        <div class="image" *ngFor="let image of images; let i = index;"
+             [class.active]="!loading && (i == activeImageIndex)"
+             [ngStyle]="{top: conf.imageOffset, bottom: conf.imageOffset}">
+            <img *ngIf="i == activeImageIndex" [src]="image.url" [alt]="image.altText || ''"
+                 [style.borderRadius]="conf.imageBorderRadius" (click)="onImageClick.next(activeImageIndex)"/>
+        </div>
 
-    <!-- loading animation -->
-    <div class="loading-animation" *ngIf="(images.length == 0) || loading">
-      <svg  version="1.1" id="L3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 100 100" enable-background="new 0 0 0 0" xml:space="preserve">
+        <!-- loading animation -->
+        <div class="loading-animation" *ngIf="(images.length == 0) || loading">
+            <svg  version="1.1" id="L3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 100 100" enable-background="new 0 0 0 0" xml:space="preserve">
         <circle fill="none" stroke="#fff" stroke-width="4" cx="50" cy="50" r="44" style="opacity:0.5;"/>
         <circle fill="#4caf50" stroke="#eee" stroke-width="3" cx="8" cy="54" r="6">
           <animateTransform
@@ -25,54 +28,60 @@
           attributeName="fill" 
           begin="1s" 
           dur="16s" 
-          values ="#4caf50; #cddc39; #ff9800; #f44336; #e91e63; #ff5722; #ffeb3b; #4caf50"
+          values="#4caf50; #cddc39; #ff9800; #f44336; #e91e63; #ff5722; #ffeb3b; #4caf50"
           repeatCount="indefinite" /> 
         </circle>
       </svg>
-    </div>
-  </div>
-
-  <!-- info and thumbnails -->
-  <div class="info-container">
-    <div class="title" 
-    *ngIf="conf.showImageTitle && !loading && activeImage && activeImage.title"
-    [style.paddingBottom]="conf.showThumbnails ? '0px' : '30px'"
-    [class.dark]="conf.inline"
-    >{{ activeImage.title }}</div>
-
-    <div #thumbnails class="thumbnails" *ngIf="conf.showThumbnails">
-      <div class="thumbnails-scroller" [style.marginLeft]="thumbnailsScrollerLeftMargin">
-        <div class="thumbnail" 
-        *ngFor="let image of images; let i = index;" 
-        [class.active]="i == activeImageIndex" 
-        [style.backgroundImage]="'url(' + (image.thumbnailUrl || image.url) + ')'"
-        [style.margin]="thumbnailMargin"
-        [style.width]="conf.thumbnailSize + 'px'"
-        [style.height]="conf.thumbnailSize + 'px'"
-        (click)="setActiveImage(i)">
-          <div class="feedback"></div>
         </div>
-      </div>
     </div>
-  </div>
+
+    <!-- info and thumbnails -->
+    <div class="info-container">
+        <div class="title"
+             *ngIf="conf.showImageTitle && !loading && activeImage && activeImage.title"
+             [style.paddingBottom]="conf.showThumbnails ? '0px' : '30px'"
+             [class.dark]="conf.inline"
+        >{{ activeImage.title }}
+        </div>
+
+        <div #thumbnails class="thumbnails" *ngIf="conf.showThumbnails">
+            <div class="thumbnails-scroller" [style.marginLeft]="thumbnailsScrollerLeftMargin">
+                <div class="thumbnail"
+                     *ngFor="let image of images; let i = index;"
+                     [class.active]="i == activeImageIndex"
+                     [style.backgroundImage]="'url(' + (image.thumbnailUrl || image.url) + ')'"
+                     [style.margin]="thumbnailMargin"
+                     [style.width]="conf.thumbnailSize + 'px'"
+                     [style.height]="conf.thumbnailSize + 'px'"
+                     (click)="setActiveImage(i)">
+                    <div class="feedback"></div>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>
 
 
 <!-- gallery controls -->
-<div class="control arrow left" *ngIf="conf.showArrows && (images.length > 1) && !loading" [class.dark]="conf.inline" [class.disabled]="onFirstImage" (click)="prev()"></div>
-<div class="control arrow right" *ngIf="conf.showArrows && (images.length > 1) && !loading" [class.dark]="conf.inline" [class.disabled]="onLastImage" (click)="next()"></div>
+<div class="control arrow left" *ngIf="conf.showArrows && (images.length > 1) && !loading" [class.dark]="conf.inline"
+     [class.disabled]="onFirstImage" (click)="prev()"></div>
+<div class="control arrow right" *ngIf="conf.showArrows && (images.length > 1) && !loading" [class.dark]="conf.inline"
+     [class.disabled]="onLastImage" (click)="next()"></div>
 
 <div class="control right-top">
-  <a class="ext-url" [class.dark]="conf.inline" *ngIf="conf.showExtUrlControl && activeImage && activeImage.extUrl && !loading" [href]="activeImage.extUrl" [target]="activeImage.extUrlTarget || '_blank'">
-    <div class="feedback"></div>
-  </a>
-  <div class="close" [class.dark]="conf.inline" *ngIf="conf.showCloseControl" (click)="close()">
-    <div class="feedback"></div>
-  </div>
+    <a class="ext-url" [class.dark]="conf.inline"
+       *ngIf="conf.showExtUrlControl && activeImage && activeImage.extUrl && !loading" [href]="activeImage.extUrl"
+       [target]="activeImage.extUrlTarget || '_blank'">
+        <div class="feedback"></div>
+    </a>
+    <div class="close" [class.dark]="conf.inline" *ngIf="conf.showCloseControl" (click)="close()">
+        <div class="feedback"></div>
+    </div>
 </div>
 
 <div class="control left-top">
-  <div class="delete-img" [class.dark]="conf.inline" *ngIf="conf.showDeleteControl && !loading" (click)="deleteImage(activeImageIndex)">
-    <div class="feedback"></div>
-  </div>
+    <div class="delete-img" [class.dark]="conf.inline" *ngIf="conf.showDeleteControl && !loading"
+         (click)="deleteImage(activeImageIndex)">
+        <div class="feedback"></div>
+    </div>
 </div>

--- a/module/components/ngx-image-gallery/ngx-image-gallery.component.ts
+++ b/module/components/ngx-image-gallery/ngx-image-gallery.component.ts
@@ -27,6 +27,7 @@ const KEY_CODES = {
 const DEFAULT_CONF: GALLERY_CONF = {
     imageBorderRadius: '3px',
     imageOffset: '20px',
+    imagePointer: false,
     showDeleteControl: false,
     showCloseControl: true,
     showExtUrlControl: true,

--- a/module/components/ngx-image-gallery/ngx-image-gallery.component.ts
+++ b/module/components/ngx-image-gallery/ngx-image-gallery.component.ts
@@ -1,344 +1,357 @@
-import { Component, OnInit, HostBinding, Input, HostListener, ElementRef, Renderer2, EventEmitter, Output, OnChanges, SimpleChanges, ViewChild } from '@angular/core';
-import { assign, findIndex, debounce } from 'lodash';
+import {
+    Component,
+    OnInit,
+    HostBinding,
+    Input,
+    HostListener,
+    ElementRef,
+    Renderer2,
+    EventEmitter,
+    Output,
+    OnChanges,
+    SimpleChanges,
+    ViewChild
+} from '@angular/core';
+import {assign, findIndex, debounce} from 'lodash';
 
-import { GALLERY_CONF, GALLERY_IMAGE } from './../../ngx-image-gallery.conf';
+import {GALLERY_CONF, GALLERY_IMAGE} from './../../ngx-image-gallery.conf';
 
 // key codes to react
 const KEY_CODES = {
-  37: 'LEFT',
-  39: 'RIGHT',
-  27: 'ESC'
+    37: 'LEFT',
+    39: 'RIGHT',
+    27: 'ESC'
 };
 
 // default gallery configuration
 const DEFAULT_CONF: GALLERY_CONF = {
-  imageBorderRadius: '3px',
-	imageOffset: '20px',
-	showDeleteControl: false,
-	showCloseControl: true,
-	showExtUrlControl: true,
-	showImageTitle: true,
-	showThumbnails: true,
-  closeOnEsc: true,
-  reactToKeyboard: true,
-	reactToMouseWheel: true,
-  reactToRightClick: false,
-  thumbnailSize: 30,
-  backdropColor: 'rgba(13,13,14,0.85)',
-  inline: false,
-  showArrows: true
+    imageBorderRadius: '3px',
+    imageOffset: '20px',
+    showDeleteControl: false,
+    showCloseControl: true,
+    showExtUrlControl: true,
+    showImageTitle: true,
+    showThumbnails: true,
+    closeOnEsc: true,
+    reactToKeyboard: true,
+    reactToMouseWheel: true,
+    reactToRightClick: false,
+    thumbnailSize: 30,
+    backdropColor: 'rgba(13,13,14,0.85)',
+    inline: false,
+    showArrows: true
 };
 
 @Component({
-  selector: 'ngx-image-gallery',
-  templateUrl: './ngx-image-gallery.component.html',
-  styleUrls: ['./ngx-image-gallery.component.scss']
+    selector: 'ngx-image-gallery',
+    templateUrl: './ngx-image-gallery.component.html',
+    styleUrls: ['./ngx-image-gallery.component.scss']
 })
 export class NgxImageGalleryComponent implements OnInit, OnChanges {
 
-  // gallery opened memory
-  @HostBinding('class.active') opened: boolean = false;
+    // gallery opened memory
+    @HostBinding('class.active') opened: boolean = false;
 
-  // gallery configuration
-  @Input() conf: GALLERY_CONF = {};
+    // gallery configuration
+    @Input() conf: GALLERY_CONF = {};
 
-  // gallery images
-  @Input() images: GALLERY_IMAGE[] = [];
+    // gallery images
+    @Input() images: GALLERY_IMAGE[] = [];
 
-  // event emmiters
-  @Output() onOpen = new EventEmitter();
-  @Output() onClose = new EventEmitter();
-  @Output() onDelete = new EventEmitter();
-  @Output() onImageChange = new EventEmitter();
+    // event emmiters
+    @Output() onOpen = new EventEmitter();
+    @Output() onClose = new EventEmitter();
+    @Output() onDelete = new EventEmitter();
+    @Output() onImageChange = new EventEmitter();
+    @Output() onImageClick = new EventEmitter<number>();
 
-  // thumbnails container
-  @ViewChild('thumbnails') thumbnailsElem: ElementRef;
+    // thumbnails container
+    @ViewChild('thumbnails') thumbnailsElem: ElementRef;
 
-  /***************************************************/
-  
-  // loading animation memory
-  loading: boolean = false;
+    /***************************************************/
 
-  // current active image index
-  activeImageIndex: number = null;
+    // loading animation memory
+    loading: boolean = false;
 
-  // thumbnail margin and scroll position
-  thumbnailMargin: string = '0px 8px';
-  thumbnailsScrollerLeftMargin: string = '0px';
+    // current active image index
+    activeImageIndex: number = null;
 
-  // active image
-  get activeImage(): GALLERY_IMAGE {
-    return this.images[this.activeImageIndex];
-  }
+    // thumbnail margin and scroll position
+    thumbnailMargin: string = '0px 8px';
+    thumbnailsScrollerLeftMargin: string = '0px';
 
-  // if gallery is on : first image
-  get onFirstImage(): boolean {
-    return this.activeImageIndex == 0;
-  }
-
-  // if gallery is on : last image
-  get onLastImage(): boolean {
-    return this.activeImageIndex == (this.images.length - 1);
-  }
-
-  // get thumbnails viewport rendering parameters
-  get thumbnailsRenderParams(): {thumbnailsInView: number, newThumbnailMargin: number, newThumbnailSize: number, thumbnailsScrollerLeftMargin: any} {
-    let thumbnailsContainerWidth = this.thumbnailsElem.nativeElement.offsetWidth;
-
-    let thumbnailMargin = 16;
-    let thumbnailSize = thumbnailMargin + this.conf.thumbnailSize;
-    let thumbnailsInView = Math.floor(thumbnailsContainerWidth / thumbnailSize);
-    let extraSpaceInThumbnailsContainer = thumbnailsContainerWidth - (thumbnailsInView * thumbnailSize);
-    let extraMargin = extraSpaceInThumbnailsContainer / thumbnailsInView;
-
-    let newThumbnailMargin = thumbnailMargin + extraMargin;
-    let newThumbnailSize = newThumbnailMargin + this.conf.thumbnailSize;
-
-    let relativePositionOfActiveImageThumbnailToScroller = thumbnailsInView - (thumbnailsInView - this.activeImageIndex);
-    let thumbnailsScrollerLeftMargin: any;
-
-    if(relativePositionOfActiveImageThumbnailToScroller > thumbnailsInView - 2){
-      var outThumbnails = ((this.activeImageIndex + 1) - thumbnailsInView) + 1;
-
-      if(this.activeImageIndex != (this.images.length - 1)){
-        thumbnailsScrollerLeftMargin = '-' + (newThumbnailSize * outThumbnails) + 'px';
-      }
-      else{
-        thumbnailsScrollerLeftMargin = '-' + (newThumbnailSize * (outThumbnails - 1)) + 'px';
-      }
-    }
-    else{
-      thumbnailsScrollerLeftMargin = '0px';
+    // active image
+    get activeImage(): GALLERY_IMAGE {
+        return this.images[this.activeImageIndex];
     }
 
-    return {
-      thumbnailsInView,
-      newThumbnailMargin,
-      newThumbnailSize,
-      thumbnailsScrollerLeftMargin
-    };
-  }
-
-  // set gallery configuration
-  private setGalleryConf(conf: GALLERY_CONF) {
-    this.conf = assign(DEFAULT_CONF, conf);
-  }
-
-  // load image and return promise
-  private loadImage(index: number): Promise<any> {
-    const galleryImage: GALLERY_IMAGE = this.images[index];
-
-    // check if image is cached
-    if(galleryImage._cached){
-      return Promise.resolve(index);
+    // if gallery is on : first image
+    get onFirstImage(): boolean {
+        return this.activeImageIndex == 0;
     }
-    else{
-      return new Promise((resolve, reject) => {
-        this.loading = true;
-        
-        let image = new Image();
-        image.src = galleryImage.url;
 
-        image.onload = () => {
-          this.loading = false;
-          galleryImage._cached = true;
-          resolve(index);
+    // if gallery is on : last image
+    get onLastImage(): boolean {
+        return this.activeImageIndex == (this.images.length - 1);
+    }
+
+    // get thumbnails viewport rendering parameters
+    get thumbnailsRenderParams(): { thumbnailsInView: number, newThumbnailMargin: number, newThumbnailSize: number, thumbnailsScrollerLeftMargin: any } {
+        let thumbnailsContainerWidth = this.thumbnailsElem.nativeElement.offsetWidth;
+
+        let thumbnailMargin = 16;
+        let thumbnailSize = thumbnailMargin + this.conf.thumbnailSize;
+        let thumbnailsInView = Math.floor(thumbnailsContainerWidth / thumbnailSize);
+        let extraSpaceInThumbnailsContainer = thumbnailsContainerWidth - (thumbnailsInView * thumbnailSize);
+        let extraMargin = extraSpaceInThumbnailsContainer / thumbnailsInView;
+
+        let newThumbnailMargin = thumbnailMargin + extraMargin;
+        let newThumbnailSize = newThumbnailMargin + this.conf.thumbnailSize;
+
+        let relativePositionOfActiveImageThumbnailToScroller = thumbnailsInView - (thumbnailsInView - this.activeImageIndex);
+        let thumbnailsScrollerLeftMargin: any;
+
+        if (relativePositionOfActiveImageThumbnailToScroller > thumbnailsInView - 2) {
+            var outThumbnails = ((this.activeImageIndex + 1) - thumbnailsInView) + 1;
+
+            if (this.activeImageIndex != (this.images.length - 1)) {
+                thumbnailsScrollerLeftMargin = '-' + (newThumbnailSize * outThumbnails) + 'px';
+            }
+            else {
+                thumbnailsScrollerLeftMargin = '-' + (newThumbnailSize * (outThumbnails - 1)) + 'px';
+            }
+        }
+        else {
+            thumbnailsScrollerLeftMargin = '0px';
+        }
+
+        return {
+            thumbnailsInView,
+            newThumbnailMargin,
+            newThumbnailSize,
+            thumbnailsScrollerLeftMargin
         };
-
-        image.onerror = (error) => {
-          this.loading = false;
-          reject(error);
-        };
-      });
-    }
-  }
-
-  // activate image (set active image)
-  private activateImage(imageIndex: number) {
-    // prevent loading if already loading
-    if(this.loading) return false;
-
-    // emit event
-    this.onImageChange.emit(imageIndex);
-
-    this.loadImage(imageIndex)
-    .then(_imageIndex => {
-      this.activeImageIndex = _imageIndex;
-
-      // scroll thumbnails
-      setTimeout(() => {
-        this.fitThumbnails();
-        setTimeout(() => this.scrollThumbnails(), 300);
-      });
-    })
-    .catch(error => console.warn(error));
-  }
-
-  // adjust thumbnail margin to perfectly fit viewport
-  private fitThumbnails = debounce(() => {
-    // if thumbnails not visible, return false
-    if(this.conf.showThumbnails == false) return false;
-
-    let thumbnailParams = this.thumbnailsRenderParams;
-    this.thumbnailMargin = '0 ' + (thumbnailParams.newThumbnailMargin/2) + 'px';
-  }, 300);
-
-  // scroll thumbnails to perfectly position active image thumbnail in viewport
-  private scrollThumbnails() {
-    // if thumbnails not visible, return false
-    if(this.conf.showThumbnails == false) return false;
-    
-    let thumbnailParams = this.thumbnailsRenderParams;
-    this.thumbnailsScrollerLeftMargin = thumbnailParams.thumbnailsScrollerLeftMargin;
-  }
-
-  // debounced prev
-  private debouncedPrev = debounce(() => this.prev(), 100, {'leading': true, 'trailing': false});
-
-  // debounced next
-  private debouncedNext = debounce(() => this.next(), 100, {'leading': true, 'trailing': false});
-
-  // keyboard event
-  @HostListener('window:keydown', ['$event'])
-  private onKeyboardInput(event: KeyboardEvent) {
-    if(this.conf.reactToKeyboard && this.opened && !this.loading) {
-      if(KEY_CODES[event.keyCode] == 'RIGHT'){
-        this.next();
-      }
-      else if(KEY_CODES[event.keyCode] == 'LEFT'){
-        this.prev();
-      }
-      else if((KEY_CODES[event.keyCode] == 'ESC') && this.conf.closeOnEsc){
-        this.close();
-      }
-    }
-  }
-
-  // window resize event
-  @HostListener('window:resize', ['$event'])
-  private onWindowResize(event: Event) {
-    if(this.opened && !this.loading) {
-      this.fitThumbnails();
-      setTimeout(() => this.scrollThumbnails(), 300);
-    }
-  }
-
-  /***************************************************/
-
-  constructor(
-    private galleryElem: ElementRef,
-    private renderer: Renderer2
-  ) { }
-
-  ngOnInit() {
-    // create final gallery configuration
-    this.setGalleryConf(this.conf);
-
-    // apply backdrop color
-    this.renderer.setStyle(this.galleryElem.nativeElement, 'background-color', this.conf.backdropColor);
-
-    // gallery inline class and auto open
-    if(this.conf.inline) {
-      this.renderer.addClass(this.galleryElem.nativeElement, 'inline');
-      this.open(0);
-    }
-  }
-
-  ngOnChanges(changes: SimpleChanges) {
-    // when gallery configuration changes
-    if(changes.conf && changes.conf.firstChange == false) {
-      this.setGalleryConf(changes.conf.currentValue);
-
-      // apply backdrop color
-      this.renderer.setStyle(this.galleryElem.nativeElement, 'background-color', this.conf.backdropColor);
-
-      // gallery inline class and auto open
-      if((changes.conf.previousValue.inline != true) && this.conf.inline) {
-        this.renderer.addClass(this.galleryElem.nativeElement, 'inline');
-        this.open(0);
-      }
     }
 
-    // when gallery images changes
-    if(changes.images && changes.images.firstChange == false) {
-      this.images = changes.images.currentValue;
-      
-      if(this.images.length){
-        this.activateImage(0);
-      }
+    // set gallery configuration
+    private setGalleryConf(conf: GALLERY_CONF) {
+        this.conf = assign(DEFAULT_CONF, conf);
     }
-    
-  }
 
-  /***************************************************/
+    // load image and return promise
+    private loadImage(index: number): Promise<any> {
+        const galleryImage: GALLERY_IMAGE = this.images[index];
 
-  // open gallery
-  open(index: number = 0) {
-    if(this.images.length) {
-      this.opened = true;
+        // check if image is cached
+        if (galleryImage._cached) {
+            return Promise.resolve(index);
+        }
+        else {
+            return new Promise((resolve, reject) => {
+                this.loading = true;
 
-      // emit event
-      this.onOpen.emit(index);
+                let image = new Image();
+                image.src = galleryImage.url;
 
-      // activate image at given index
-      this.activateImage(index);
+                image.onload = () => {
+                    this.loading = false;
+                    galleryImage._cached = true;
+                    resolve(index);
+                };
+
+                image.onerror = (error) => {
+                    this.loading = false;
+                    reject(error);
+                };
+            });
+        }
     }
-    else{
-      console.warn('No images provided to ngx-image-gallery!');
+
+    // activate image (set active image)
+    private activateImage(imageIndex: number) {
+        // prevent loading if already loading
+        if (this.loading) return false;
+
+        // emit event
+        this.onImageChange.emit(imageIndex);
+
+        this.loadImage(imageIndex)
+            .then(_imageIndex => {
+                this.activeImageIndex = _imageIndex;
+
+                // scroll thumbnails
+                setTimeout(() => {
+                    this.fitThumbnails();
+                    setTimeout(() => this.scrollThumbnails(), 300);
+                });
+            })
+            .catch(error => console.warn(error));
     }
-  }
 
-  // close gallery
-  close() {
-    this.opened = false;
-    this.activeImageIndex = 0;
+    // adjust thumbnail margin to perfectly fit viewport
+    private fitThumbnails = debounce(() => {
+        // if thumbnails not visible, return false
+        if (this.conf.showThumbnails == false) return false;
 
-    // emit event
-    this.onClose.emit();
-  }
+        let thumbnailParams = this.thumbnailsRenderParams;
+        this.thumbnailMargin = '0 ' + (thumbnailParams.newThumbnailMargin / 2) + 'px';
+    }, 300);
 
-  // change prev image
-  prev() {
-    if(this.onFirstImage == false){
-      this.activateImage(this.activeImageIndex - 1);
+    // scroll thumbnails to perfectly position active image thumbnail in viewport
+    private scrollThumbnails() {
+        // if thumbnails not visible, return false
+        if (this.conf.showThumbnails == false) return false;
+
+        let thumbnailParams = this.thumbnailsRenderParams;
+        this.thumbnailsScrollerLeftMargin = thumbnailParams.thumbnailsScrollerLeftMargin;
     }
-  }
 
-  // change next image
-  next() {
-    if(this.onLastImage == false){
-      this.activateImage(this.activeImageIndex + 1);
+    // debounced prev
+    private debouncedPrev = debounce(() => this.prev(), 100, {'leading': true, 'trailing': false});
+
+    // debounced next
+    private debouncedNext = debounce(() => this.next(), 100, {'leading': true, 'trailing': false});
+
+    // keyboard event
+    @HostListener('window:keydown', ['$event'])
+    private onKeyboardInput(event: KeyboardEvent) {
+        if (this.conf.reactToKeyboard && this.opened && !this.loading) {
+            if (KEY_CODES[event.keyCode] == 'RIGHT') {
+                this.next();
+            }
+            else if (KEY_CODES[event.keyCode] == 'LEFT') {
+                this.prev();
+            }
+            else if ((KEY_CODES[event.keyCode] == 'ESC') && this.conf.closeOnEsc) {
+                this.close();
+            }
+        }
     }
-  }
 
-  // set image (activate)
-  setActiveImage(index: number) {
-    this.activateImage(index);
-  }
-
-  // delete image
-  deleteImage(index: number) {
-    this.onDelete.emit(index);
-  }
-
-  // mouse wheel up (prev image)
-  mouseWheelUp() {
-    if(this.conf.reactToMouseWheel) {
-      this.debouncedNext();
+    // window resize event
+    @HostListener('window:resize', ['$event'])
+    private onWindowResize(event: Event) {
+        if (this.opened && !this.loading) {
+            this.fitThumbnails();
+            setTimeout(() => this.scrollThumbnails(), 300);
+        }
     }
-  }
 
-  // mouse wheel down (next image)
-  mouseWheelDown() {
-    if(this.conf.reactToMouseWheel) {
-      this.debouncedPrev();
+    /***************************************************/
+
+    constructor(private galleryElem: ElementRef,
+                private renderer: Renderer2) {
     }
-  }
 
-  // right click on image
-  rightClickOnImage(event: Event) {
-    event.stopPropagation();
-    return this.conf.reactToRightClick;
-  }
+    ngOnInit() {
+        // create final gallery configuration
+        this.setGalleryConf(this.conf);
+
+        // apply backdrop color
+        this.renderer.setStyle(this.galleryElem.nativeElement, 'background-color', this.conf.backdropColor);
+
+        // gallery inline class and auto open
+        if (this.conf.inline) {
+            this.renderer.addClass(this.galleryElem.nativeElement, 'inline');
+            this.open(0);
+        }
+    }
+
+    ngOnChanges(changes: SimpleChanges) {
+        // when gallery configuration changes
+        if (changes.conf && changes.conf.firstChange == false) {
+            this.setGalleryConf(changes.conf.currentValue);
+
+            // apply backdrop color
+            this.renderer.setStyle(this.galleryElem.nativeElement, 'background-color', this.conf.backdropColor);
+
+            // gallery inline class and auto open
+            if ((changes.conf.previousValue.inline != true) && this.conf.inline) {
+                this.renderer.addClass(this.galleryElem.nativeElement, 'inline');
+                this.open(0);
+            }
+        }
+
+        // when gallery images changes
+        if (changes.images && changes.images.firstChange == false) {
+            this.images = changes.images.currentValue;
+
+            if (this.images.length) {
+                this.activateImage(0);
+            }
+        }
+
+    }
+
+    /***************************************************/
+
+    // open gallery
+    open(index: number = 0) {
+        if (this.images.length) {
+            this.opened = true;
+
+            // emit event
+            this.onOpen.emit(index);
+
+            // activate image at given index
+            this.activateImage(index);
+        }
+        else {
+            console.warn('No images provided to ngx-image-gallery!');
+        }
+    }
+
+    // close gallery
+    close() {
+        this.opened = false;
+        this.activeImageIndex = 0;
+
+        // emit event
+        this.onClose.emit();
+    }
+
+    // change prev image
+    prev() {
+        if (this.onFirstImage == false) {
+            this.activateImage(this.activeImageIndex - 1);
+        }
+    }
+
+    // change next image
+    next() {
+        if (this.onLastImage == false) {
+            this.activateImage(this.activeImageIndex + 1);
+        }
+    }
+
+    // set image (activate)
+    setActiveImage(index: number) {
+        this.activateImage(index);
+    }
+
+    // delete image
+    deleteImage(index: number) {
+        this.onDelete.emit(index);
+    }
+
+    // mouse wheel up (prev image)
+    mouseWheelUp() {
+        if (this.conf.reactToMouseWheel) {
+            this.debouncedNext();
+        }
+    }
+
+    // mouse wheel down (next image)
+    mouseWheelDown() {
+        if (this.conf.reactToMouseWheel) {
+            this.debouncedPrev();
+        }
+    }
+
+    // right click on image
+    rightClickOnImage(event: Event) {
+        event.stopPropagation();
+        return this.conf.reactToRightClick;
+    }
 
 }

--- a/module/ngx-image-gallery.conf.ts
+++ b/module/ngx-image-gallery.conf.ts
@@ -1,7 +1,8 @@
 export interface GALLERY_CONF {
 	imageBorderRadius?: string;
-	imageOffset?: string;
-	showDeleteControl?: boolean;
+    imageOffset?: string;
+    imagePointer? :boolean;
+    showDeleteControl?: boolean;
 	showCloseControl?: boolean;
 	showExtUrlControl?: boolean;
 	showArrows?: boolean;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-image-gallery",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Probably the best Angular 4+ modal & inline image gallery. Angular upgrade for ng-image-gallery.",
   "main": "index.ts",
   "scripts": {


### PR DESCRIPTION
Hi,

i added a event emitter that will emit an event when the user click
on the main image of the gallery. This can be helpful to provide to the end user more
custom information about the pic, "debug purposes", or some extras.

In my case i use in one template two times the `ngx-image-gallery`.
One inline and the second not. Using the output event of the `onImageClicked` i can use the 
`ngx-image-gallery` as full screen. When i click on close --> the template will return the inline one. Since other devs may not need this feature, i made the cursor pointer of the img optional via conf interface.
By default it's set to false. When need it, we can turn it to true via conf.

Thank you